### PR TITLE
refactor: replace @Component with @Repository on repository classes

### DIFF
--- a/payment-receipt-service/src/main/kotlin/br/com/developers/receipt/PaymentReceiptRepository.kt
+++ b/payment-receipt-service/src/main/kotlin/br/com/developers/receipt/PaymentReceiptRepository.kt
@@ -1,12 +1,12 @@
 package br.com.developers.receipt
 
 import io.awspring.cloud.dynamodb.DynamoDbOperations
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Repository
 import software.amazon.awssdk.enhanced.dynamodb.Key
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest
 
-@Component
+@Repository
 class PaymentReceiptRepository(private val dynamoDbOperations: DynamoDbOperations) {
 
     fun findByPk(id: String): PaymentReceipt? {

--- a/payment-service/src/main/kotlin/br/com/developers/payment/PaymentRepository.kt
+++ b/payment-service/src/main/kotlin/br/com/developers/payment/PaymentRepository.kt
@@ -1,11 +1,11 @@
 package br.com.developers.payment
 import io.awspring.cloud.dynamodb.DynamoDbTemplate
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Repository
 import software.amazon.awssdk.enhanced.dynamodb.Key
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest
 
-@Component
+@Repository
 class PaymentRepository(private val dynamoDbTemplate: DynamoDbTemplate) {
     fun findByPk(id: String): Payment? {
         val key = Key.builder()


### PR DESCRIPTION
## Summary

- Changes `@Component` to `@Repository` on `PaymentRepository` and `PaymentReceiptRepository`
- `@Repository` is semantically correct for data-access classes and enables Spring's persistence exception translation
- No behaviour change

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4BQzgtNx2xcyBrf2omGzd)_