### PR TITLE
refactor: extract TTL calculation into ttlOf60Minutes() utility

### DIFF
--- a/payment-receipt-service/src/main/kotlin/br/com/developers/receipt/PaymentReceipt.kt
+++ b/payment-receipt-service/src/main/kotlin/br/com/developers/receipt/PaymentReceipt.kt
@@ -3,8 +3,6 @@ package br.com.developers.receipt
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey
-import java.time.Duration
-import java.time.Instant
 import java.time.LocalDate
 import java.util.*
 
@@ -26,5 +24,5 @@ data class PaymentReceipt (
     var pixKeyCredit: String? = null,
 
     @get:DynamoDbAttribute(value = "ttl")
-    var ttl: Long = Instant.now().plus(Duration.ofMinutes(60)).epochSecond
+    var ttl: Long = ttlOf60Minutes()
 )

--- a/payment-receipt-service/src/main/kotlin/br/com/developers/receipt/TtlUtils.kt
+++ b/payment-receipt-service/src/main/kotlin/br/com/developers/receipt/TtlUtils.kt
@@ -1,0 +1,6 @@
+package br.com.developers.receipt
+
+import java.time.Duration
+import java.time.Instant
+
+fun ttlOf60Minutes(): Long = Instant.now().plus(Duration.ofMinutes(60)).epochSecond

--- a/payment-receipt-service/src/test/kotlin/br/com/developers/payment/TtlUtilsTest.kt
+++ b/payment-receipt-service/src/test/kotlin/br/com/developers/payment/TtlUtilsTest.kt
@@ -1,0 +1,31 @@
+package br.com.developers.receipt
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.greaterThanOrEqualTo
+import org.hamcrest.Matchers.lessThanOrEqualTo
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+@DisplayName("TtlUtils test")
+class TtlUtilsTest {
+
+    @Test
+    fun `Should return epoch second 60 minutes from now`() {
+        val now = Instant.now()
+        val ttl = ttlOf60Minutes()
+
+        assertThat(ttl, greaterThanOrEqualTo(now.plus(Duration.ofMinutes(59)).epochSecond))
+        assertThat(ttl, lessThanOrEqualTo(now.plus(Duration.ofMinutes(61)).epochSecond))
+    }
+
+    @Test
+    fun `Should set PaymentReceipt ttl to 60 minutes from now`() {
+        val now = Instant.now()
+        val receipt = PaymentReceipt()
+
+        assertThat(receipt.ttl, greaterThanOrEqualTo(now.plus(Duration.ofMinutes(59)).epochSecond))
+        assertThat(receipt.ttl, lessThanOrEqualTo(now.plus(Duration.ofMinutes(61)).epochSecond))
+    }
+}

--- a/payment-service/src/main/kotlin/br/com/developers/payment/Payment.kt
+++ b/payment-service/src/main/kotlin/br/com/developers/payment/Payment.kt
@@ -5,8 +5,6 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey
 import java.math.BigDecimal
-import java.time.Duration
-import java.time.Instant
 import java.time.LocalDate
 import java.util.*
 
@@ -31,7 +29,7 @@ data class Payment (
     var pixKeyCredit: String? = null,
 
     @get:DynamoDbAttribute(value = "ttl")
-    var ttl: Long = Instant.now().plus(Duration.ofMinutes(60)).epochSecond
+    var ttl: Long = ttlOf60Minutes()
 ) {
     override fun toString(): String {
         return "Payment{" +

--- a/payment-service/src/main/kotlin/br/com/developers/payment/TtlUtils.kt
+++ b/payment-service/src/main/kotlin/br/com/developers/payment/TtlUtils.kt
@@ -1,0 +1,6 @@
+package br.com.developers.payment
+
+import java.time.Duration
+import java.time.Instant
+
+fun ttlOf60Minutes(): Long = Instant.now().plus(Duration.ofMinutes(60)).epochSecond

--- a/payment-service/src/test/kotlin/br/com/developers/payment/TtlUtilsTest.kt
+++ b/payment-service/src/test/kotlin/br/com/developers/payment/TtlUtilsTest.kt
@@ -1,0 +1,31 @@
+package br.com.developers.payment
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.greaterThanOrEqualTo
+import org.hamcrest.Matchers.lessThanOrEqualTo
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+@DisplayName("TtlUtils test")
+class TtlUtilsTest {
+
+    @Test
+    fun `Should return epoch second 60 minutes from now`() {
+        val now = Instant.now()
+        val ttl = ttlOf60Minutes()
+
+        assertThat(ttl, greaterThanOrEqualTo(now.plus(Duration.ofMinutes(59)).epochSecond))
+        assertThat(ttl, lessThanOrEqualTo(now.plus(Duration.ofMinutes(61)).epochSecond))
+    }
+
+    @Test
+    fun `Should set Payment ttl to 60 minutes from now`() {
+        val now = Instant.now()
+        val payment = Payment()
+
+        assertThat(payment.ttl, greaterThanOrEqualTo(now.plus(Duration.ofMinutes(59)).epochSecond))
+        assertThat(payment.ttl, lessThanOrEqualTo(now.plus(Duration.ofMinutes(61)).epochSecond))
+    }
+}


### PR DESCRIPTION
## Summary

- Both `Payment.kt` and `PaymentReceipt.kt` duplicated `Instant.now().plus(Duration.ofMinutes(60)).epochSecond` inline
- Extracts this into a `ttlOf60Minutes(): Long` top-level function in a new `TtlUtils.kt` per service
- Entities now call `ttlOf60Minutes()` as their TTL default value
- Makes the 60-minute window change-proof (one place to update) and self-documenting

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4BQzgtNx2xcyBrf2omGzd)_