### PR TITLE
refactor: remove nullable params from service interfaces

### DIFF
--- a/payment-receipt-service/src/main/kotlin/br/com/developers/receipt/PaymentReceiptService.kt
+++ b/payment-receipt-service/src/main/kotlin/br/com/developers/receipt/PaymentReceiptService.kt
@@ -2,7 +2,6 @@ package br.com.developers.receipt
 
 interface PaymentReceiptService {
 
-    fun save(paymentReceipt: PaymentReceipt?)
-
-    fun findById (id: String?): PaymentReceipt
+    fun save(paymentReceipt: PaymentReceipt)
+    fun findById(id: String): PaymentReceipt
 }

--- a/payment-receipt-service/src/main/kotlin/br/com/developers/receipt/PaymentReceiptServiceImpl.kt
+++ b/payment-receipt-service/src/main/kotlin/br/com/developers/receipt/PaymentReceiptServiceImpl.kt
@@ -6,13 +6,11 @@ import org.springframework.stereotype.Service
 @Service
 internal class PaymentReceiptServiceImpl(
     private val paymentReceiptRepository: PaymentReceiptRepository
-) :
-    PaymentReceiptService {
+) : PaymentReceiptService {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
-    override fun save(paymentReceipt: PaymentReceipt?) {
-        checkNotNull(paymentReceipt)
+    override fun save(paymentReceipt: PaymentReceipt) {
         checkNotNull(paymentReceipt.pk)
         log.info("Saving payment receipt $paymentReceipt")
 
@@ -26,8 +24,7 @@ internal class PaymentReceiptServiceImpl(
         log.info("Payment receipt saved ${paymentReceiptSaved.pk}")
     }
 
-    override fun findById(id: String?): PaymentReceipt {
-        checkNotNull(id)
+    override fun findById(id: String): PaymentReceipt {
         log.info("Finding receipt by $id")
 
         return paymentReceiptRepository.findByPk(id) ?: throw PaymentReceiptNotFoundException("Payment $id not found")

--- a/payment-receipt-service/src/test/kotlin/br/com/developers/payment/PaymentReceiptConsumerTest.kt
+++ b/payment-receipt-service/src/test/kotlin/br/com/developers/payment/PaymentReceiptConsumerTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
-import org.mockito.ArgumentCaptor
 import org.mockito.kotlin.*
 import org.springframework.messaging.MessageHeaders
 import java.time.LocalDate
@@ -24,7 +23,7 @@ class PaymentReceiptConsumerTest {
     private val paymentReceiptService: PaymentReceiptService = mock()
     private val messageHeaders: MessageHeaders = mock()
     private val acknowledgment: Acknowledgement = mock()
-    private val argumentCaptor = ArgumentCaptor.forClass(PaymentReceipt::class.java)
+    private val argumentCaptor = argumentCaptor<PaymentReceipt>()
 
     private lateinit var paymentReceiptConsumer: PaymentReceiptConsumer
 
@@ -61,12 +60,12 @@ class PaymentReceiptConsumerTest {
 
         verify(this.paymentReceiptService, atLeastOnce()).save(this.argumentCaptor.capture())
         assertAll("Assert payment request event", {
-            assertThat(this.argumentCaptor.value.pk, `is`(equalTo(UUID.fromString(paymentReceiptRequest.id))))
-            assertThat(this.argumentCaptor.value.status, `is`(equalTo(EventType.PROCESSED_PAYMENT.name)))
-            assertThat(this.argumentCaptor.value.inclusionDate, `is`(equalTo(LocalDate.now())))
-            assertThat(this.argumentCaptor.value.paymentDate, `is`(equalTo(paymentReceiptRequest.date)))
-            assertThat(this.argumentCaptor.value.pixKeyCredit, `is`(equalTo(paymentReceiptRequest.pixKeyCredit)))
-            assertThat(this.argumentCaptor.value.ttl, `is`(notNullValue()))
+            assertThat(this.argumentCaptor.firstValue.pk, `is`(equalTo(UUID.fromString(paymentReceiptRequest.id))))
+            assertThat(this.argumentCaptor.firstValue.status, `is`(equalTo(EventType.PROCESSED_PAYMENT.name)))
+            assertThat(this.argumentCaptor.firstValue.inclusionDate, `is`(equalTo(LocalDate.now())))
+            assertThat(this.argumentCaptor.firstValue.paymentDate, `is`(equalTo(paymentReceiptRequest.date)))
+            assertThat(this.argumentCaptor.firstValue.pixKeyCredit, `is`(equalTo(paymentReceiptRequest.pixKeyCredit)))
+            assertThat(this.argumentCaptor.firstValue.ttl, `is`(notNullValue()))
         })
     }
 }

--- a/payment-receipt-service/src/test/kotlin/br/com/developers/payment/PaymentReceiptServiceTest.kt
+++ b/payment-receipt-service/src/test/kotlin/br/com/developers/payment/PaymentReceiptServiceTest.kt
@@ -22,15 +22,6 @@ class PaymentReceiptServiceTest {
     }
 
     @Test
-    fun `Should test the invalid payment receipt`() {
-        val exception = assertThrows<IllegalStateException> {
-            this.paymentReceiptService.save(null)
-        }
-
-        assertThat(exception.message, `is`(equalTo("Required value was null.")))
-    }
-
-    @Test
     fun `Should test the saved payment receipt`() {
         val paymentReceipt = PaymentReceipt().apply {
             this.pk = UUID.fromString("44c7516-075b-4b52-8e90-9bb2207ce41c")
@@ -61,15 +52,6 @@ class PaymentReceiptServiceTest {
 
         verify(this.paymentReceiptRepository, atLeastOnce()).update(eq(paymentReceipt))
         verify(this.paymentReceiptRepository, never()).save(eq(paymentReceipt))
-    }
-
-    @Test
-    fun `Should test the invalid id in find by id`() {
-        val exception = assertThrows<IllegalStateException> {
-            this.paymentReceiptService.findById(null)
-        }
-
-        assertThat(exception.message, `is`(equalTo("Required value was null.")))
     }
 
     @Test

--- a/payment-service/src/main/kotlin/br/com/developers/event/PaymentEventPublisher.kt
+++ b/payment-service/src/main/kotlin/br/com/developers/event/PaymentEventPublisher.kt
@@ -16,9 +16,7 @@ class PaymentEventPublisher(
 
     private val log = LoggerFactory.getLogger(javaClass)
 
-    fun publish(paymentEventRequest: PaymentEventRequest?) {
-        checkNotNull(paymentEventRequest)
-
+    fun publish(paymentEventRequest: PaymentEventRequest) {
         kotlin.runCatching {
             val message: Message<PaymentEventRequest> = MessageBuilder.withPayload(paymentEventRequest)
                 .setHeader("event_type", paymentEventRequest.eventType.orEmpty())

--- a/payment-service/src/main/kotlin/br/com/developers/payment/PaymentService.kt
+++ b/payment-service/src/main/kotlin/br/com/developers/payment/PaymentService.kt
@@ -2,7 +2,7 @@ package br.com.developers.payment
 
 interface PaymentService {
 
-    fun save (payment: Payment?)
-    fun findById (id: String?): Payment
-    fun delete(id: String?)
+    fun save(payment: Payment)
+    fun findById(id: String): Payment
+    fun delete(id: String)
 }

--- a/payment-service/src/main/kotlin/br/com/developers/payment/PaymentServiceImpl.kt
+++ b/payment-service/src/main/kotlin/br/com/developers/payment/PaymentServiceImpl.kt
@@ -13,8 +13,7 @@ internal class PaymentServiceImpl(
 
     private val log = LoggerFactory.getLogger(javaClass)
 
-    override fun save(payment: Payment?) {
-        checkNotNull(payment)
+    override fun save(payment: Payment) {
         log.info("Saving payment $payment")
 
         val paymentSaved = this.paymentRepository.save(payment)
@@ -30,15 +29,13 @@ internal class PaymentServiceImpl(
         }
     }
 
-    override fun findById(id: String?): Payment {
-        checkNotNull(id)
+    override fun findById(id: String): Payment {
         log.info("Finding by $id")
 
         return paymentRepository.findByPk(id) ?: throw PaymentNotFoundException("Payment $id not found")
     }
 
-    override fun delete(id: String?) {
-        checkNotNull(id)
+    override fun delete(id: String) {
         log.info("Deleting payment $id")
 
         val payment =

--- a/payment-service/src/test/kotlin/br/com/developers/payment/PaymentServiceTest.kt
+++ b/payment-service/src/test/kotlin/br/com/developers/payment/PaymentServiceTest.kt
@@ -7,7 +7,6 @@ import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.ArgumentCaptor
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
 import java.math.BigDecimal
@@ -20,22 +19,13 @@ class PaymentServiceTest {
 
     private val paymentRepository: PaymentRepository = mock()
     private val paymentEventPublisher: PaymentEventPublisher = mock()
-    private val argumentCaptor = ArgumentCaptor.forClass(PaymentEventRequest::class.java)
+    private val argumentCaptor = argumentCaptor<PaymentEventRequest>()
 
     private lateinit var paymentService: PaymentService
 
     @BeforeEach
-    fun before () {
+    fun before() {
         this.paymentService = PaymentServiceImpl(this.paymentRepository, this.paymentEventPublisher)
-    }
-
-    @Test
-    fun `Should test the invalid payment`() {
-        val exception = assertThrows<IllegalStateException> {
-            this.paymentService.save(null)
-        }
-
-        assertThat(exception.message, `is`(equalTo("Required value was null.")))
     }
 
     @Test
@@ -56,19 +46,10 @@ class PaymentServiceTest {
         verify(this.paymentRepository, atLeastOnce()).save(eq(payment))
         verify(this.paymentEventPublisher, atLeastOnce()).publish(this.argumentCaptor.capture())
         assertAll("Assert payment request event", {
-            assertThat(this.argumentCaptor.value.id, `is`(equalTo(payment.pk.toString())))
-            assertThat(this.argumentCaptor.value.eventType, `is`(equalTo(payment.sk)))
-            assertThat(this.argumentCaptor.value.pixKeyCredit, `is`(equalTo(payment.pixKeyCredit)))
+            assertThat(this.argumentCaptor.firstValue.id, `is`(equalTo(payment.pk.toString())))
+            assertThat(this.argumentCaptor.firstValue.eventType, `is`(equalTo(payment.sk)))
+            assertThat(this.argumentCaptor.firstValue.pixKeyCredit, `is`(equalTo(payment.pixKeyCredit)))
         })
-    }
-
-    @Test
-    fun `Should test the invalid id in find by id`() {
-        val exception = assertThrows<IllegalStateException> {
-            this.paymentService.findById(null)
-        }
-
-        assertThat(exception.message, `is`(equalTo("Required value was null.")))
     }
 
     @Test
@@ -104,15 +85,6 @@ class PaymentServiceTest {
     }
 
     @Test
-    fun `Should test the invalid id in delete`() {
-        val exception = assertThrows<IllegalStateException> {
-            this.paymentService.delete(null)
-        }
-
-        assertThat(exception.message, `is`(equalTo("Required value was null.")))
-    }
-
-    @Test
     fun `Should test the not found payment in delete`() {
         val id = "8d369a41-a278-4390-9fc8-9cd32425bf4c"
         whenever(this.paymentRepository.findByPk(id))
@@ -141,7 +113,7 @@ class PaymentServiceTest {
 
         assertThat(exception.message, `is`(equalTo("Payment processed $id can't be change")))
         verify(this.paymentRepository, never()).delete(eq(payment))
-        verify(this.paymentEventPublisher, never()).publish(this.argumentCaptor.capture())
+        verify(this.paymentEventPublisher, never()).publish(any())
     }
 
     @Test
@@ -159,9 +131,9 @@ class PaymentServiceTest {
         verify(this.paymentRepository, atLeastOnce()).delete(eq(payment))
         verify(this.paymentEventPublisher, atLeastOnce()).publish(this.argumentCaptor.capture())
         assertAll("Assert payment request event", {
-            assertThat(this.argumentCaptor.value.id, `is`(equalTo(payment.pk.toString())))
-            assertThat(this.argumentCaptor.value.eventType, `is`(equalTo(EventType.DELETED_PAYMENT.name)))
-            assertThat(this.argumentCaptor.value.pixKeyCredit, `is`(equalTo(payment.pixKeyCredit)))
+            assertThat(this.argumentCaptor.firstValue.id, `is`(equalTo(payment.pk.toString())))
+            assertThat(this.argumentCaptor.firstValue.eventType, `is`(equalTo(EventType.DELETED_PAYMENT.name)))
+            assertThat(this.argumentCaptor.firstValue.pixKeyCredit, `is`(equalTo(payment.pixKeyCredit)))
         })
     }
 }

--- a/payment-service/src/test/kotlin/br/com/developers/payment/event/PaymentEventPublisherTest.kt
+++ b/payment-service/src/test/kotlin/br/com/developers/payment/event/PaymentEventPublisherTest.kt
@@ -9,7 +9,6 @@ import org.hamcrest.MatcherAssert.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
@@ -26,16 +25,7 @@ class PaymentEventPublisherTest {
 
     @BeforeEach
     fun before() {
-        this.paymentEventPublisher = PaymentEventPublisher(this.snsTemplate,"topic-test")
-    }
-
-    @Test
-    fun `Should test the invalid payment request`() {
-        val exception = assertThrows<IllegalStateException> {
-            this.paymentEventPublisher.publish(null)
-        }
-
-        assertThat(exception.message, `is`(equalTo("Required value was null.")))
+        this.paymentEventPublisher = PaymentEventPublisher(this.snsTemplate, "topic-test")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `PaymentService`, `PaymentReceiptService`, and `PaymentEventPublisher` methods accepted nullable types (`Payment?`, `String?`) but immediately called `checkNotNull()` — null enforcement was deferred to runtime
- Changes all parameters to non-null types, expressing the contract at the type level
- Removes the now-redundant `checkNotNull()` calls from service implementations
- Removes 5 unit tests that validated null-argument behaviour (compile-time enforcement replaces them)
- Migrates `ArgumentCaptor.forClass()` (Java) to mockito-kotlin's `argumentCaptor<T>()` to stay compatible with non-null method signatures

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4BQzgtNx2xcyBrf2omGzd)_